### PR TITLE
fix https://github.com/theantichris/granola/issues/15

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,16 +21,16 @@ func NewRootCmd(logger *log.Logger) *cobra.Command {
 		Use:   "granola",
 		Short: "An application for exporting Granola meeting notes.",
 		Long:  "An application for exporting Granola meeting notes to Markdown files.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config")); err != nil {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlag("config", cmd.Root().PersistentFlags().Lookup("config")); err != nil {
 				return fmt.Errorf("%w: %s", ErrRootCmd, err)
 			}
 
-			if err := viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug")); err != nil {
+			if err := viper.BindPFlag("debug", cmd.Root().PersistentFlags().Lookup("debug")); err != nil {
 				return fmt.Errorf("%w: %s", ErrRootCmd, err)
 			}
 
-			if err := viper.BindPFlag("supabase", cmd.PersistentFlags().Lookup("supabase")); err != nil {
+			if err := viper.BindPFlag("supabase", cmd.Root().PersistentFlags().Lookup("supabase")); err != nil {
 				return fmt.Errorf("%w: %s", ErrRootCmd, err)
 			}
 


### PR DESCRIPTION
tested and working:

```shell
go install .
```

and then
```shell
# works!
granola notes --supabase $HOME/Library/Application\ Support/Granola/supabase.json
# works!
granola transcripts
```

gpt-5.2-codex's explanation of the change:

> The change makes sure the root‑level flags are bound in a hook that always runs for subcommands.
 Previously the bindings happened in PreRunE and used the current command’s flags, so when you ran
 granola notes the root flags (--config, --debug, --supabase) weren’t always visible and viper never
 picked them up. By switching to PersistentPreRunE and binding from cmd.Root().PersistentFlags(), those
 global flags are available to every subcommand, so granola notes reads the correct config and works
 again.